### PR TITLE
feat: support database url at build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ RUN mkdir uploads
 COPY portfolio-social/package*.json ./
 RUN npm install
 COPY portfolio-social .
+ARG DATABASE_URL
+ENV DATABASE_URL=$DATABASE_URL
 RUN npx prisma generate
 
 FROM node:20


### PR DESCRIPTION
## Summary
- expose DATABASE_URL arg in server Docker build stage

## Testing
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68a4932b32008327ae08a73715750ef9