### PR TITLE
Normalize Docker ignore paths

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,40 +1,54 @@
-# flyctl launch added from portfolio-social\.gitignore
-portfolio-social\**\node_modules
+# flyctl launch added from portfolio-social/.gitignore
+portfolio-social/**/node_modules
 # Keep environment variables out of version control
-portfolio-social\**\.env
+portfolio-social/**/.env
 
-portfolio-social\**\uploads
+portfolio-social/**/uploads
 # Ignore log files
 
-# flyctl launch added from portfolio-social-client\.gitignore
+# flyctl launch added from portfolio-social-client/.gitignore
 # Logs
-portfolio-social-client\**\logs
-portfolio-social-client\**\*.log
-portfolio-social-client\**\npm-debug.log*
-portfolio-social-client\**\yarn-debug.log*
-portfolio-social-client\**\yarn-error.log*
-portfolio-social-client\**\pnpm-debug.log*
-portfolio-social-client\**\lerna-debug.log*
+portfolio-social-client/**/logs
+portfolio-social-client/**/*.log
+portfolio-social-client/**/npm-debug.log*
+portfolio-social-client/**/yarn-debug.log*
+portfolio-social-client/**/yarn-error.log*
+portfolio-social-client/**/pnpm-debug.log*
+portfolio-social-client/**/lerna-debug.log*
 
-portfolio-social-client\**\node_modules
-portfolio-social-client\**\dist
-portfolio-social-client\**\dist-ssr
-portfolio-social-client\**\*.local
+portfolio-social-client/**/node_modules
+portfolio-social-client/**/dist
+portfolio-social-client/**/dist-ssr
+portfolio-social-client/**/*.local
 
 # Editor directories and files
-portfolio-social-client\**\.vscode\*
-!portfolio-social-client\**\.vscode\extensions.json
-portfolio-social-client\**\.idea
-portfolio-social-client\**\.DS_Store
-portfolio-social-client\**\*.suo
-portfolio-social-client\**\*.ntvs*
-portfolio-social-client\**\*.njsproj
-portfolio-social-client\**\*.sln
-portfolio-social-client\**\*.sw?
+portfolio-social-client/**/.vscode/*
+!portfolio-social-client/**/.vscode/extensions.json
+portfolio-social-client/**/.idea
+portfolio-social-client/**/.DS_Store
+portfolio-social-client/**/*.suo
+portfolio-social-client/**/*.ntvs*
+portfolio-social-client/**/*.njsproj
+portfolio-social-client/**/*.sln
+portfolio-social-client/**/*.sw?
 
-
-portfolio-social-client\**\pnpm-lock.yaml
-portfolio-social-client\**\yarn.lock
-portfolio-social-client\**\package-lock.json
-portfolio-social-client\**\bun.lockb
+portfolio-social-client/**/pnpm-lock.yaml
+portfolio-social-client/**/yarn.lock
+portfolio-social-client/**/package-lock.json
+portfolio-social-client/**/bun.lockb
 fly.toml
+
+# Global ignores
+**/node_modules
+**/dist
+**/build
+**/.env
+**/uploads
+**/logs
+**/*.log
+**/npm-debug.log*
+**/yarn-debug.log*
+**/yarn-error.log*
+**/pnpm-debug.log*
+**/lerna-debug.log*
+


### PR DESCRIPTION
## Summary
- replace Windows-style paths with forward slashes in `.dockerignore`
- add global ignore entries for common build artifacts, env files, uploads, and logs

## Testing
- `cd portfolio-social && npm test` *(fails: Missing script "test")*
- `cd portfolio-social-client && npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a494006c548327b5ec5e854a2c0140