### PR TITLE
docs: add docker usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,19 @@
+# Social App
+
+## Docker
+
+Соберите и запустите приложение в Docker:
+
+```bash
+docker build -t social-app \
+  --build-arg VITE_BASE_URL=<frontend-url> \
+  --build-arg DATABASE_URL=<mongo-url> \
+  .
+
+docker run -p 3000:3000 \
+  -e DATABASE_URL=<mongo-url> \
+  -e SECRET_KEY=<секрет> \
+  social-app
+```
+
+При необходимости директорию `uploads` следует монтировать как volume для сохранения загруженных файлов.


### PR DESCRIPTION
## Summary
- add README with Docker build/run instructions

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68a4948775708327ac80f053ac4f06de