### PR TITLE
feat: configure client url via env

### DIFF
--- a/portfolio-social/.env
+++ b/portfolio-social/.env
@@ -1,0 +1,1 @@
+CLIENT_URL=https://frontend.example.com

--- a/portfolio-social/app.js
+++ b/portfolio-social/app.js
@@ -13,13 +13,13 @@ const app = express();
 
 app.use(express.static(path.join(__dirname, 'public')));
 
-app.use(cors({
-  origin: [
-    'http://localhost:5173',
-    'http://localhost',
-    'http://127.0.0.1'
+const allowedOrigins = (process.env.CLIENT_URL || '')
+  .split(',')
+  .map(origin => origin.trim())
+  .filter(Boolean);
 
-  ],
+app.use(cors({
+  origin: allowedOrigins,
   credentials: true,
   methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
   allowedHeaders: ['Content-Type', 'Authorization'],


### PR DESCRIPTION
## Summary
- configure CORS allowed origins from CLIENT_URL environment variable
- add CLIENT_URL to server .env

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a5a41648808327a0ca5fecca4b98e0