### PR TITLE
feat: add API root endpoint

### DIFF
--- a/portfolio-social/app.js
+++ b/portfolio-social/app.js
@@ -51,13 +51,7 @@ if (!fs.existsSync('uploads')) {
   fs.mkdirSync('uploads');
 }
 
-
-app.get('*', (req, res, next) => {
-  if (!req.path.startsWith('/api')) {
-    return res.sendFile(path.join(__dirname, 'public', 'index.html'));
-  }
-  return next();
-});
+app.get('/', (_req, res) => res.json({ message: 'API is running' }));
 
 app.use((req, res, next) => {
   next(createError(404));


### PR DESCRIPTION
## Summary
- replace catch-all route with simple root endpoint returning JSON message

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a5b1896ba88327a24626ea2ed0b1b7