### PR TITLE
Configure Cloudinary via explicit env vars

### DIFF
--- a/portfolio-social/.env
+++ b/portfolio-social/.env
@@ -1,3 +1,5 @@
 CLIENT_URL=https://frontend.example.com
-CLOUDINARY_URL=cloudinary://API_KEY:API_SECRET@CLOUD_NAME
+CLOUDINARY_CLOUD_NAME=your_cloud_name
+CLOUDINARY_API_KEY=your_api_key
+CLOUDINARY_API_SECRET=your_api_secret
 

--- a/portfolio-social/controllers/user-controller.js
+++ b/portfolio-social/controllers/user-controller.js
@@ -4,7 +4,12 @@ const { prisma } = require("../prisma/prisma-client");
 const Jdenticon = require('jdenticon');
 const cloudinary = require('cloudinary').v2;
 
-cloudinary.config({ secure: true });
+cloudinary.config({
+    cloud_name: process.env.CLOUDINARY_CLOUD_NAME,
+    api_key: process.env.CLOUDINARY_API_KEY,
+    api_secret: process.env.CLOUDINARY_API_SECRET,
+    secure: true,
+});
 
 const UserController = {
     register: async (req, res) => {


### PR DESCRIPTION
## Summary
- define individual Cloudinary env variables in `.env`
- configure Cloudinary client using explicit credentials from env variables

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a5be9d23d08327927ddc537857afc0