### PR TITLE
Use Cloudinary avatar URLs

### DIFF
--- a/portfolio-social-client/src/components/profile/index.tsx
+++ b/portfolio-social-client/src/components/profile/index.tsx
@@ -2,7 +2,6 @@ import { selectCurrent } from "@/features/user/userSlice"
 import { Card, CardBody, CardHeader } from "@heroui/card";
 import { useSelector } from "react-redux"
 import {Image} from "@heroui/image";
-import { BASE_URL } from "@/constans";
 import { Link } from "react-router-dom";
 import { MdAlternateEmail } from "react-icons/md";
 
@@ -24,7 +23,7 @@ export const Profile = () => {
             <Image
                 alt='Card profile'
                 className="onject-cover rounded-xl"
-                src={`${BASE_URL}${avatarUrl}`}
+                src={avatarUrl}
                 width={370}
             />
         </CardHeader>

--- a/portfolio-social-client/src/components/user/index.tsx
+++ b/portfolio-social-client/src/components/user/index.tsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import { User as HeroUiUser} from '@heroui/user'
-import { BASE_URL } from '@/constans';
 
 type Props = {
     name: string;
@@ -22,7 +21,7 @@ export const User: React.FC<Props> = ({
         description={description}
         className={className}
         avatarProps={{
-            src: `${BASE_URL}${avatarUrl}`,
+            src: avatarUrl,
         }}
     />
   )

--- a/portfolio-social-client/src/pages/userProfile/index.tsx
+++ b/portfolio-social-client/src/pages/userProfile/index.tsx
@@ -7,7 +7,6 @@ import { useEffect } from "react";
 import { GoBack } from "@/components/go-back";
 import { Card } from "@heroui/card";
 import { Image } from "@heroui/image";
-import { BASE_URL } from "@/constans";
 import { Button } from "@heroui/button";
 import { MdOutlinePersonAddAlt1, MdOutlinePersonAddDisabled } from "react-icons/md";
 import { CiEdit } from "react-icons/ci";
@@ -72,7 +71,7 @@ export const UserProfile = () => {
       <div className="flex items-center gap-4">
         <Card className="flex flex-col items-center text-center space-y-4 p-5 flex-2">
           <Image
-            src={`${BASE_URL}${data.avatarUrl}`}
+            src={data.avatarUrl}
             alt={data.name}
             width={200}
             height={200}

--- a/portfolio-social/app.js
+++ b/portfolio-social/app.js
@@ -43,8 +43,6 @@ async function connectToDatabase() {
 
 connectToDatabase();
 
-app.use('/uploads', express.static('uploads'));
-
 app.use('/api', require('./routes'));
 
 if (!fs.existsSync('uploads')) {

--- a/portfolio-social/package.json
+++ b/portfolio-social/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "scripts": {
     "start": "node ./bin/www",
-    "dev": "nodemon ./bin/www"
+    "dev": "nodemon ./bin/www",
+    "cleanup:avatars": "node scripts/cleanup-avatar-urls.js"
   },
   "dependencies": {
     "@prisma/client": "^6.10.1",

--- a/portfolio-social/scripts/cleanup-avatar-urls.js
+++ b/portfolio-social/scripts/cleanup-avatar-urls.js
@@ -1,0 +1,33 @@
+const { prisma } = require('../prisma/prisma-client');
+
+async function main() {
+  const defaultUrl = process.env.CLOUDINARY_DEFAULT_AVATAR_URL;
+  if (!defaultUrl) {
+    console.error('CLOUDINARY_DEFAULT_AVATAR_URL is not set');
+    process.exit(1);
+  }
+
+  const users = await prisma.user.findMany({
+    where: { avatarUrl: { contains: 'uploads/' } },
+  });
+
+  for (const user of users) {
+    await prisma.user.update({
+      where: { id: user.id },
+      data: { avatarUrl: defaultUrl },
+    });
+    console.log(`Updated user ${user.id}`);
+  }
+
+  console.log(`Updated ${users.length} users`);
+}
+
+main()
+  .catch(e => {
+    console.error(e);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });
+


### PR DESCRIPTION
## Summary
- remove express static serving of local uploads
- provide script to clean up old avatar URLs in the database
- load user avatars via absolute URLs on the client

## Testing
- `npm test` (server) *(fails: Missing script "test")*
- `npm test` (client) *(fails: Missing script "test")*
- `npx eslint . --ext .ts,.tsx` *(fails: 1292 problems, including 3 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a5c00db8c883279146eb11986efaf6